### PR TITLE
Added the --enable-pic option to the ffmpeg build in the build.rs pro…

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -103,6 +103,8 @@ fn build() -> io::Result<()> {
 	// do not build programs since we don't need them
 	configure.arg("--disable-programs");
 
+	configure.arg("--enable-pic");
+
 	macro_rules! switch {
 		($conf:expr, $feat:expr, $name:expr) => (
 			if env::var(concat!("CARGO_FEATURE_", $feat)).is_ok() {


### PR DESCRIPTION
…gram.

@ryandbair This fixed the -fpic error.  This still requires the double build because of the check.c problem.
