### PR TITLE
Added support for linking to lzma, bz2, dl, and rt via feature support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ffmpeg-sys"
-version = "2.8.7"
+version = "2.8.6"
 build   = "build.rs"
 links   = "ffmpeg"
 
@@ -29,8 +29,12 @@ build-license-nonfree  = ["build"]
 build-license-version3 = ["build"]
 
 # misc
-build-pic  = ["build"]
-build-zlib = ["build"]
+build-pic   = ["build"]
+build-zlib  = ["build"]
+build-lzma  = ["build"]
+build-bz2   = ["build"]
+build-dl    = ["build"]
+build-rt    = ["build"]
 
 # ssl
 build-lib-gnutls  = ["build"]

--- a/build.rs
+++ b/build.rs
@@ -342,11 +342,24 @@ fn check_features(infos: &Vec<(&'static str, Option<&'static str>, &'static str)
 }
 
 fn main() {
+
 	if env::var("CARGO_FEATURE_BUILD").is_ok() {
+		macro_rules! link_native {
+			($feat_name:expr, $lib_name:expr) => (
+				if env::var(concat!("CARGO_FEATURE_BUILD_", $feat_name)).is_ok() {
+					println!("cargo:rustc-link-lib={}", $lib_name);
+				}
+			)
+		}
+
 		println!("cargo:rustc-link-search=native={}", search().join("lib").to_string_lossy());
 
-		if env::var("CARGO_FEATURE_BUILD_ZLIB").is_ok() && cfg!(target_os = "linux") {
-			println!("cargo:rustc-link-lib=z");
+		if cfg!(target_os = "linux") {
+			link_native!("ZLIB", "z");
+			link_native!("LZMA", "lzma");
+			link_native!("BZ2", "bz2");
+			link_native!("DL", "dl");
+			link_native!("RT", "rt");
 		}
 
 		if fs::metadata(&search().join("lib").join("libavutil.a")).is_ok() {


### PR DESCRIPTION
@ryandbair I added dl and rt although I haven't needed them in tlx 2 yet.  I needed them in the c++ version and decided to knock them out in the hopes of not having to do this yak shaving again soon.
