### PR TITLE
Fix build feature. Always detect enabled features and fix include path.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -291,7 +291,7 @@ fn check_features(infos: &Vec<(&'static str, Option<&'static str>, &'static str)
 		};
 
 	if !Command::new(compiler).current_dir(&out_dir)
-		.arg("-I").arg(search().join("dist").join("include").to_string_lossy().into_owned())
+		.arg("-I").arg(search().join("include").to_string_lossy().into_owned())
 		.arg("-o").arg(&executable)
 		.arg("check.c")
 		.status().expect("Command failed").success() {
@@ -362,14 +362,13 @@ fn main() {
 			link_native!("RT", "rt");
 		}
 
-		if fs::metadata(&search().join("lib").join("libavutil.a")).is_ok() {
-			return;
+		let build_required = fs::metadata(&search().join("lib").join("libavutil.a")).is_err();
+		if build_required {
+			fs::create_dir_all(&output()).ok().expect("failed to create build directory");
+			fetch().unwrap();
+			extract().unwrap();
+			build().unwrap();
 		}
-
-		fs::create_dir_all(&output()).ok().expect("failed to create build directory");
-		fetch().unwrap();
-		extract().unwrap();
-		build().unwrap();
 	}
 
 


### PR DESCRIPTION
Two super important changes here:
- The output of `search()` already included dist, don't include it again. This fixes the missing libavutil.h problem on the first build. Which plays into...
- Don't return early if the binaries are already built. We need to call `check_features` or else the features will not be written to stdout and the Rust code will be compiled without them.

With this change, the size of AVPacket is the same (96 bytes) in both Rust and C. 
