### PR TITLE
patch ffmpeg to fix read/write flags on rtp sockets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -79,6 +79,25 @@ fn extract() -> io::Result<()> {
 	}
 }
 
+fn patch() -> io::Result<()> {
+	let root = env::var("CARGO_MANIFEST_DIR").unwrap();
+	let status = try!(
+		Command::new("patch")
+			.current_dir(&source())
+			.arg("-p1")
+			.arg("-i")
+			.arg(format!("{}/rtsp_read_write.patch", root))
+			.status()
+	);
+
+	if status.success() {
+		Ok(())
+	}
+	else {
+		Err(io::Error::new(io::ErrorKind::Other, "patch failed"))
+	}
+}
+
 fn build() -> io::Result<()> {
 	let mut configure = Command::new("./configure");
 	configure.current_dir(&source());
@@ -366,6 +385,7 @@ fn main() {
 			fs::create_dir_all(&output()).ok().expect("failed to create build directory");
 			fetch().unwrap();
 			extract().unwrap();
+			patch().unwrap();
 			build().unwrap();
 		}
 		

--- a/rtsp_read_write.patch
+++ b/rtsp_read_write.patch
@@ -1,0 +1,37 @@
+diff --git a/libavformat/rtpproto.c b/libavformat/rtpproto.c
+index 538a7b2..e8c8558 100644
+--- a/libavformat/rtpproto.c
++++ b/libavformat/rtpproto.c
+@@ -393,7 +393,7 @@ static int rtp_open(URLContext *h, const char *uri, int flags)
+             build_udp_url(s, buf, sizeof(buf),
+                           hostname, s->rtcp_port, s->local_rtcpport,
+                           sources, block);
+-            if (ffurl_open_whitelist(&s->rtcp_hd, buf, flags,
++            if (ffurl_open_whitelist(&s->rtcp_hd, buf, flags|AVIO_FLAG_WRITE,
+                                      &h->interrupt_callback, NULL,
+                                      h->protocol_whitelist) < 0) {
+                 s->local_rtpport = s->local_rtcpport = -1;
+@@ -404,7 +404,8 @@ static int rtp_open(URLContext *h, const char *uri, int flags)
+         build_udp_url(s, buf, sizeof(buf),
+                       hostname, s->rtcp_port, s->local_rtcpport,
+                       sources, block);
+-        if (ffurl_open_whitelist(&s->rtcp_hd, buf, flags, &h->interrupt_callback,
++        if (ffurl_open_whitelist(&s->rtcp_hd, buf, flags|AVIO_FLAG_WRITE, 
++                                 &h->interrupt_callback,
+                                  NULL, h->protocol_whitelist) < 0)
+             goto fail;
+         break;
+diff --git a/libavformat/rtsp.c b/libavformat/rtsp.c
+index d710469..b37369a 100644
+--- a/libavformat/rtsp.c
++++ b/libavformat/rtsp.c
+@@ -2316,7 +2316,8 @@ static int sdp_read_header(AVFormatContext *s)
+             append_source_addrs(url, sizeof(url), "block",
+                                 rtsp_st->nb_exclude_source_addrs,
+                                 rtsp_st->exclude_source_addrs);
+-            err = ffurl_open_whitelist(&rtsp_st->rtp_handle, url, AVIO_FLAG_READ_WRITE,
++            err = ffurl_open_whitelist(&rtsp_st->rtp_handle, url,
++                           s->pb->write_flag ? AVIO_FLAG_READ_WRITE : AVIO_FLAG_READ,
+                            &s->interrupt_callback, &opts, s->protocol_whitelist);
+ 
+             av_dict_free(&opts);


### PR DESCRIPTION
This patch works by setting the write flag on the RT(S)P socket only if the AVIO context is writable. In our usage, the AVIO context is never writable. This is necessary as FFmpeg only sets the source address on multicast sockets when the socket is not writable. This is important as you cannot write messages to a socket where the system does not have the IP address that is set as the sockets source address, as is the case with multicast. 

The RTCP socket gets special cased and we always set it writable so control messages can still be written, even with a read-only AVIOContext.