### PR TITLE
rtcp filter version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -81,21 +81,26 @@ fn extract() -> io::Result<()> {
 
 fn patch() -> io::Result<()> {
 	let root = env::var("CARGO_MANIFEST_DIR").unwrap();
-	let status = try!(
-		Command::new("patch")
-			.current_dir(&source())
-			.arg("-p1")
-			.arg("-i")
-			.arg(format!("{}/rtsp_read_write.patch", root))
-			.status()
-	);
 
-	if status.success() {
-		Ok(())
-	}
-	else {
-		Err(io::Error::new(io::ErrorKind::Other, "patch failed"))
-	}
+	let apply_patch = |patch: &str| {
+		let status = try!(
+			Command::new("patch")
+				.current_dir(&source())
+				.arg("-p1")
+				.arg("-i")
+				.arg(format!("{}/{}", root, patch))
+				.status()
+		);
+
+		if status.success() {
+			Ok(())
+		} else {
+			Err(io::Error::new(io::ErrorKind::Other, format!("patch {} failed", patch)))
+		}
+	};
+
+	let patches: Vec<&str> = vec!["rtsp_read_write.patch", "discard_invalid_rtcp.patch"];
+	patches.into_iter().fold(Ok(()), |acc, patch| acc.and(apply_patch(&patch)))
 }
 
 fn build() -> io::Result<()> {

--- a/build.rs
+++ b/build.rs
@@ -116,6 +116,7 @@ fn build() -> io::Result<()> {
 	if env::var("DEBUG").is_ok() {
 		configure.arg("--enable-debug");
 		configure.arg("--disable-stripping");
+		configure.arg("--optflags='-Og'");
 	}
 	else {
 		configure.arg("--disable-debug");

--- a/discard_invalid_rtcp.patch
+++ b/discard_invalid_rtcp.patch
@@ -1,0 +1,60 @@
+diff --git a/libavformat/rtpdec.c b/libavformat/rtpdec.c
+index c3e50d4..2ba0385 100644
+--- a/libavformat/rtpdec.c
++++ b/libavformat/rtpdec.c
+@@ -144,30 +144,35 @@ static int rtcp_parse_packet(RTPDemuxContext *s, const unsigned char *buf,
+                              int len)
+ {
+     int payload_len;
++    int rtcp_version;
++
+     while (len >= 4) {
+         payload_len = FFMIN(len, (AV_RB16(buf + 2) + 1) * 4);
++        rtcp_version = buf[0] >> 6;
++
++        if (rtcp_version == 2) {
++            switch (buf[1]) {
++            case RTCP_SR:
++                if (payload_len < 20) {
++                    av_log(NULL, AV_LOG_ERROR,
++                           "Invalid length for RTCP SR packet\n");
++                    return AVERROR_INVALIDDATA;
++                }
++
++                s->last_rtcp_reception_time = av_gettime_relative();
++                s->last_rtcp_ntp_time  = AV_RB64(buf + 8);
++                s->last_rtcp_timestamp = AV_RB32(buf + 16);
++                if (s->first_rtcp_ntp_time == AV_NOPTS_VALUE) {
++                    s->first_rtcp_ntp_time = s->last_rtcp_ntp_time;
++                    if (!s->base_timestamp)
++                        s->base_timestamp = s->last_rtcp_timestamp;
++                    s->rtcp_ts_offset = (int32_t)(s->last_rtcp_timestamp - s->base_timestamp);
++                }
+ 
+-        switch (buf[1]) {
+-        case RTCP_SR:
+-            if (payload_len < 20) {
+-                av_log(NULL, AV_LOG_ERROR,
+-                       "Invalid length for RTCP SR packet\n");
+-                return AVERROR_INVALIDDATA;
+-            }
+-
+-            s->last_rtcp_reception_time = av_gettime_relative();
+-            s->last_rtcp_ntp_time  = AV_RB64(buf + 8);
+-            s->last_rtcp_timestamp = AV_RB32(buf + 16);
+-            if (s->first_rtcp_ntp_time == AV_NOPTS_VALUE) {
+-                s->first_rtcp_ntp_time = s->last_rtcp_ntp_time;
+-                if (!s->base_timestamp)
+-                    s->base_timestamp = s->last_rtcp_timestamp;
+-                s->rtcp_ts_offset = (int32_t)(s->last_rtcp_timestamp - s->base_timestamp);
++                break;
++            case RTCP_BYE:
++                return -RTCP_BYE;
+             }
+-
+-            break;
+-        case RTCP_BYE:
+-            return -RTCP_BYE;
+         }
+ 
+         buf += payload_len;


### PR DESCRIPTION
Filters out RTCP packets that do not have the correct version in the header. Tested against a capture of feed 406934 from tc01.las.